### PR TITLE
fixed chart not zooming

### DIFF
--- a/src/components/ChartDrehzahl.vue
+++ b/src/components/ChartDrehzahl.vue
@@ -6,8 +6,11 @@
 
 <script>
 import Chart from 'chart.js/auto';
-import 'chartjs-plugin-zoom';
+// import 'chartjs-plugin-zoom';
+import zoomPlugin from 'chartjs-plugin-zoom';
 import 'hammerjs';
+
+Chart.register(zoomPlugin);
 
 export default {
   mounted() {
@@ -49,19 +52,30 @@ export default {
             }
           },
           plugins: {
+            // zoom: {
+            //   pan: {
+            //     enabled: true,
+            //     mode: 'x',
+            //     threshold: 10,
+            //   },
+            //   zoom: {
+            //     mode: 'xy',
+            //     overScaleMode: 'xy',
+            //     wheel: {
+            //       enabled: true,
+            //       speed: 0.1,
+            //     }
+            //   }
+            // }
             zoom: {
-              pan: {
-                enabled: true,
-                mode: 'x',
-                threshold: 10,
-              },
               zoom: {
-                mode: 'xy',
-                overScaleMode: 'xy',
                 wheel: {
                   enabled: true,
-                  speed: 0.1,
-                }
+                },
+                pinch: {
+                  enabled: true
+                },
+                mode: 'xy',
               }
             }
           }


### PR DESCRIPTION
I needed to import the zoom plugin properly and register it in chartjs. I guessed you are trying to perform a specific type of zoom with your configuration but it's not working. I have changed the zoom options and it's working fine. If you need a different type of options just just look through the documentation.